### PR TITLE
Update and Enable GitHub Actions Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install Python setuptools
       run: python3 -m pip install setuptools
     - name: Install Dependencies
-      run: npm install
+      run: yarn install
     - name: Test
       run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,23 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: ['master']
 
 jobs:
  Build:
   runs-on: ubuntu-latest
   env:
-    NODE_VERSION: 4.4.7
+    NODE_VERSION: 16
     CC: clang
     CXX: clang++
     npm_config_clang: 1
   steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 6
+        node-version: ${{ env.NODE_VERSION }}
     - name: Install Dependencies
       run: npm install
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
  Build:
-  runs-on: ubuntu-latest
+  runs-on: ubuntu-20.04
+  strategy:
+    fail-fast: false
   env:
     NODE_VERSION: 16
     CC: clang
@@ -18,8 +20,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: Install OS Dependencies
-      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd wget squashfs-tools
     - name: Install Python setuptools
       run: python3 -m pip install setuptools
     - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Install Python setuptools
       run: python3 -m pip install setuptools
     - name: Install Dependencies
-      run: yarn install
+      run: npm install
     - name: Test
       run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+    - name: Install OS Dependencies
+      run: apt-get update && apt-get install -y git python3 python3-pip make gcc g++ libx11-dev libxkbfile-dev pkg-config libsecret-1-dev rpm xvfb ffmpeg zstd wget squashfs-tools
+    - name: Install Python setuptools
+      run: python3 -m pip install setuptools
     - name: Install Dependencies
       run: npm install
     - name: Test


### PR DESCRIPTION
This PR ensures we can run tests on this repository.

Also ensuring we update how we run our tests to ensure things will work within Pulsar on our current version of NodeJS.

---

EDIT:

Currently this repo is unable to install properly to run it's tests. This is not a fault of CI, but instead the fault of our `package-lock.json` file being so far out of date. Refer to DeeDeeG's comments for a much better explanation. This PR will leave things broken here, but will rely on further PRs to fix and resolve those issues.