### PR TITLE
Fix/Enable CI & Bump `git-utils` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,23 @@
 name: CI
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: ['master']
 
 jobs:
  Build:
   runs-on: ubuntu-latest
   env:
-    NODE_VERSION: 4.4.7
+    NODE_VERSION: 16
     CC: clang
     CXX: clang++
     npm_config_clang: 1
   steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 6
+        node-version: ${{ env.NODE_VERSION }}
     - name: Install Dependencies
       run: npm install
     - name: Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -294,12 +294,12 @@
       "dev": true
     },
     "git-utils": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.0.tgz",
-      "integrity": "sha512-eOBROJEQPQtkqzZe5V0m43YhKjhmzXTqULxlhoaCwORClnHtZIwkJQTS6THXRbvIqDq/cRHta85IqTbVzdvB5g==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.7.3.tgz",
+      "integrity": "sha512-in1hjFfmzY86gKBt+YMTaVyCGtX2WTnN0uPj37bI5HsrnU2oj8OFcWOEzOI5PxQXPMxFxtvRebOHAOGB8M125w==",
       "requires": {
         "fs-plus": "^3.0.0",
-        "nan": "^2.0.0"
+        "nan": "^2.14.2"
       }
     },
     "glob": {
@@ -753,9 +753,9 @@
       }
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
     },
     "nopt": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "http://atom.github.io/scandal",
   "dependencies": {
     "argparse": "^1.0.2",
-    "git-utils": "^5.6.0",
+    "git-utils": "^5.7.3",
     "isbinaryfile": "^2.0.4",
     "minimatch": "^2.0.9",
     "split": "^1.0.0",


### PR DESCRIPTION
As we previously discovered in #2 & #3 to get CI fully functional, all we may need to do is apply a `patch` on `package-lock.json` to get our deps updated, along with of course bumping them within the `package.json` which will allow us to install our dependencies and test on them.

Hopefully in much the same style as originally intended, without much fluff in our CI.