### PR TITLE
Publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: NPM Publish
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 16
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "scandal",
+  "name": "@pulsar-edit/scandal",
   "version": "3.2.0",
   "description": "Directory search and scan utilities",
   "main": "./src/scandal.js",


### PR DESCRIPTION
It's not in the checklist, but it's worth publishing a version of `scandal` as `@pulsar-edit/scandal` _before_ I update the dependencies. Assuming we'll do at least one more Pulsar release before we do the big Electron upgrade, we can update the dependency on this and enjoy one new fix — the lack of an extraneous line in the developer tools console whenever `scandal` is used.

This PR changes the package's name to `@pulsar-edit/scandal` and adds a `publish` workflow. I'll grant the NPM secret to this repo. Once it lands, we can put out a minor release, then update the `git-utils` dependency and publish a version suitable for inclusion in PulsarNext.