### PR TITLE
Bump to newest `git-utils`…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
  Build:
   runs-on: ubuntu-latest
   env:
-    NODE_VERSION: 16
+    NODE_VERSION: 20
     CC: clang
     CXX: clang++
     npm_config_clang: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 20
   NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "scandal",
+  "name": "@pulsar-edit/scandal",
   "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "scandal",
+      "name": "@pulsar-edit/scandal",
       "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
+        "@pulsar-edit/git-utils": "^7.0.1",
         "argparse": "^1.0.2",
-        "git-utils": "^5.7.3",
         "isbinaryfile": "^3.0.3",
         "minimatch": "^2.0.9",
         "split": "^1.0.0",
@@ -22,6 +22,17 @@
       "devDependencies": {
         "jasmine-focused": "^1.0.7",
         "wrench": "^1.5.8"
+      }
+    },
+    "node_modules/@pulsar-edit/git-utils": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@pulsar-edit/git-utils/-/git-utils-7.0.1.tgz",
+      "integrity": "sha512-ZFrx+c/+4wrJD7IdEZbTh5RXpmnyLFINSPqzqtmtnNhuBbUxXIFG7BYglJ5N8c4ffJP4JjWzqQqBdYb/6BM16w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-plus": "^3.0.0",
+        "nan": "^2.14.2"
       }
     },
     "node_modules/amdefine": {
@@ -229,16 +240,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/git-utils": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.7.3.tgz",
-      "integrity": "sha512-in1hjFfmzY86gKBt+YMTaVyCGtX2WTnN0uPj37bI5HsrnU2oj8OFcWOEzOI5PxQXPMxFxtvRebOHAOGB8M125w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "fs-plus": "^3.0.0",
-        "nan": "^2.14.2"
       }
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "http://atom.github.io/scandal",
   "dependencies": {
     "argparse": "^1.0.2",
-    "git-utils": "^5.7.3",
+    "@pulsar-edit/git-utils": "^7.0.1",
     "isbinaryfile": "^3.0.3",
     "minimatch": "^2.0.9",
     "split": "^1.0.0",

--- a/src/path-filter.js
+++ b/src/path-filter.js
@@ -11,7 +11,7 @@
  */
 
 const {Minimatch} = require('minimatch');
-const GitUtils = require('git-utils');
+const GitUtils = require('@pulsar-edit/git-utils');
 const path = require('path');
 const fs = require('fs');
 
@@ -29,7 +29,7 @@ class PathFilter {
   // * `rootPath` {String} top level directory to scan. eg. `/Users/ben/somedir`
   // * `options` {Object} options hash
   //   * `excludeVcsIgnores` {Boolean}; default false; true to exclude paths
-  //      defined in a .gitignore. Uses git-utils to check ignred files.
+  //      defined in a .gitignore. Uses git-utils to check ignored files.
   //   * `inclusions` {Array} of patterns to include. Uses minimatch with a couple
   //      additions: `['dirname']` and `['dirname/']` will match all paths in
   //      directory dirname.

--- a/src/path-scanner.js
+++ b/src/path-scanner.js
@@ -39,7 +39,7 @@ class PathScanner extends EventEmitter {
   // * `rootPath` {String} top level directory to scan. eg. `/Users/ben/somedir`
   // * `options` {Object} options hash
   //   * `excludeVcsIgnores` {Boolean}; default false; true to exclude paths
-  //      defined in a .gitignore. Uses git-utils to check ignred files.
+  //      defined in a .gitignore. Uses git-utils to check ignored files.
   //   * `inclusions` {Array} of patterns to include. Uses minimatch with a couple
   //      additions: `['dirname']` and `['dirname/']` will match all paths in
   //      directory dirname.


### PR DESCRIPTION
…and point CI at Node 20 (to match Electron 30.0.9).

Now that we've got a stable release of `@pulsar-edit/scandal` that should work on latest `master`, it's time to publish a new major version that will be usable on Electron 30. I've opened this as a PR so I can verify that CI passes; if it does, I'll merge this and publish a new major-version release.